### PR TITLE
feat: improve `max_attempts` default to factor in `max_completions`

### DIFF
--- a/lua/blink-copilot/config.lua
+++ b/lua/blink-copilot/config.lua
@@ -1,9 +1,11 @@
 local M = {}
 
 ---@class Config
+---@field max_completions integer Maximum number of completions to show
+---@field max_attempts? integer Maximum number of attempts to fetch completions
+---@field kind string Specifies the type of completion item to display
 M.options = {
 	max_completions = 3,
-	max_attempts = 4,
 	kind = "Copilot",
 }
 
@@ -11,6 +13,9 @@ M.options = {
 ---@param user_opts Config
 function M.init(user_opts)
 	M.options = vim.tbl_deep_extend("force", M.options, user_opts)
+	if not M.options.max_attempts then
+		M.options.max_attempts = M.options.max_completions + 1
+	end
 end
 
 return M


### PR DESCRIPTION
This automatically applies the recommended `max_attempts = max_completions + 1` if the user hasn't manually specified it. Also adds type annotations for auto completion.