### PR TITLE
docs: add missing comma in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ within `sources.provider.copilot.opts` is sufficient.
       providers = {
         copilot = {
           name = "copilot",
-          module = "blink-copilot"
+          module = "blink-copilot",
           score_offset = 100,
           async = true,
           opts = {


### PR DESCRIPTION
Add missing comma in the detailed configuration