### PR TITLE
refactor: use inlineCompletionProvider LSP client

### DIFF
--- a/lua/blink-copilot/source.lua
+++ b/lua/blink-copilot/source.lua
@@ -32,22 +32,16 @@ function M:detect_lsp_client()
 		return
 	end
 
-	local copilot_lua_clients = vim.lsp.get_clients({ name = "copilot" })
-	local copilot_vim_clients = vim.lsp.get_clients({ name = "GitHub Copilot" })
-
-	if copilot_lua_clients and copilot_lua_clients[1] then
-		self.client = copilot_lua_clients[1]
-		local ok, clt = pcall(require, "copilot.client")
-		self.is_copilot_enabled = function()
-			return ok and clt and not clt.is_disabled()
+	local lsp_clients = vim.lsp.get_clients({ bufnr = 0 })
+	for _, client in ipairs(lsp_clients) do
+		if client.server_capabilities.inlineCompletionProvider then
+			self.client = client
+			self.is_copilot_enabled = function()
+				local ok, clt = pcall(require, "copilot.client")
+				return ok and clt and not clt.is_disabled()
+			end
+			return
 		end
-
-		return
-	end
-
-	self.client = copilot_vim_clients and copilot_vim_clients[1]
-	self.is_copilot_enabled = function()
-		return vim.g.copilot_enabled ~= 0
 	end
 end
 

--- a/lua/blink-copilot/source.lua
+++ b/lua/blink-copilot/source.lua
@@ -32,15 +32,15 @@ function M:detect_lsp_client()
 		return
 	end
 
-	local lsp_clients = vim.lsp.get_clients({ bufnr = 0 })
+	local lsp_clients = vim.lsp.get_clients({ bufnr = 0, method = "textDocument/inlineCompletion" })
 	for _, client in ipairs(lsp_clients) do
-		if client.server_capabilities.inlineCompletionProvider then
+		if string.find(string.lower(client.name), "copilot") then
 			self.client = client
 			self.is_copilot_enabled = function()
-				local ok, clt = pcall(require, "copilot.client")
-				return ok and clt and not clt.is_disabled()
+				local copilot_lua, clt = pcall(require, "copilot.client")
+				return (copilot_lua and clt and not clt.is_disabled()) or (vim.g.copilot_enabled ~= 0)
 			end
-			return
+			break
 		end
 	end
 end


### PR DESCRIPTION
This refactor improves client detection by replacing the previous detection of Copilot clients with iterating over LSP clients with inlineCompletionProvider capability.

This means lsp is returned explicitly by capability rather than name.
Related to 
https://github.com/copilotlsp-nvim/copilot-lsp/issues/4