### PR TITLE
A little changes in README for Copilot language server

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,20 +70,22 @@ Here are some example configuration for using `blink-copilot` with [lazy.nvim][l
 2. Sign in to Copilot:
    - Run `:LspCopilotSignIn` to sign in
 
-**Configuration:**
+---
+
+**Option 1: Automatic Setup (Recommended)**
+
+<details>
+<summary>Using <code>mason-lspconfig.nvim</code> (simpler)</summary>
+
+This approach automatically handles the LSP server setup for you.
 
 ```lua
 {
-  -- Install mason-lspconfig to manage LSP servers
   "williamboman/mason-lspconfig.nvim",
   opts = {
-    ensure_installed = {
-      "copilot"
-    },
+    ensure_installed = { "copilot" },
   },
-  dependencies = {
-    "williamboman/mason.nvim",
-  },
+  dependencies = { "williamboman/mason.nvim" },
 },
 {
   "saghen/blink.cmp",
@@ -103,11 +105,57 @@ Here are some example configuration for using `blink-copilot` with [lazy.nvim][l
 },
 ```
 
+</details>
+
+---
+
+**Option 2: Manual Setup**
+
+<details>
+<summary>Using <code>mason.nvim</code> + <code>nvim-lspconfig</code> (more control)</summary>
+
+This approach gives you more control over the LSP configuration.
+
+```lua
+{
+  "neovim/nvim-lspconfig",
+  opts = {
+    servers = {
+      copilot = {},
+    },
+  },
+},
+{
+  "mason-org/mason.nvim",
+  opts = { ensure_installed = { "copilot" } },
+},
+{
+  "saghen/blink.cmp",
+  dependencies = { "fang2hou/blink-copilot" },
+  opts = {
+    sources = {
+      default = { "lsp", "path", "snippets", "buffer", "copilot" },
+      providers = {
+        copilot = {
+          name = "copilot",
+          module = "blink-copilot",
+          async = true,
+        },
+      },
+    },
+  },
+},
+```
+
+</details>
+
+---
+
 **Important Notes:**
 
-- Use `mason-lspconfig.nvim` to install LSP servers, not `mason.nvim` directly
 - The package name in Mason is `copilot`, not `copilot-language-server`
-- You don't need to configure `nvim-lspconfig` servers manually - `blink-copilot` handles the LSP integration automatically
+- `blink-copilot` handles the LSP integration automatically - you don't need additional LSP configuration
+- Choose Option 1 for simplicity, Option 2 for more control over LSP settings
 - The Copilot Language Server will be available after installation through Mason
 
 </details>
@@ -290,7 +338,7 @@ You can check the [official documentation][copilot-lsp-github].
 },
 {
   "mason-org/mason.nvim",
-  opts = { ensure_installed = { "copilot-language-server" } },
+  opts = { ensure_installed = { "copilot" } },
 },
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,23 +60,55 @@ Here are some example configuration for using `blink-copilot` with [lazy.nvim][l
 <details>
 <summary><code>blink-copilot</code> + <code>Copilot Language Server</code></summary>
 
-Sign in to Copilot, or use the `:LspCopilotSignIn` command from <https://github.com/neovim/nvim-lspconfig>.
+**Installation Steps:**
+
+1. Install the Copilot Language Server via Mason:
+   - Open Neovim and run `:Mason`
+   - Search for `copilot` and install it
+   - Or use `:LspInstall copilot` to install it directly
+
+2. Sign in to Copilot:
+   - Run `:Copilot auth` or follow the authentication flow when first using Copilot
+
+**Configuration:**
 
 ```lua
 {
-  "neovim/nvim-lspconfig",
+  -- Install mason-lspconfig to manage LSP servers
+  "williamboman/mason-lspconfig.nvim",
   opts = {
-    servers = {
-      copilot = {},
+    ensure_installed = {
+      "copilot", -- Note: The package name is now just "copilot", not "copilot-language-server"
     },
+  },
+  dependencies = {
+    "williamboman/mason.nvim",
   },
 },
 {
-  -- If you are using mason.nvim, you can install copilot-language-server automatically
-  "mason-org/mason.nvim",
-  opts = { ensure_installed = { "copilot-language-server" } },
+  "saghen/blink.cmp",
+  dependencies = { "fang2hou/blink-copilot" },
+  opts = {
+    sources = {
+      default = { "lsp", "path", "snippets", "buffer", "copilot" },
+      providers = {
+        copilot = {
+          name = "copilot",
+          module = "blink-copilot",
+          async = true,
+        },
+      },
+    },
+  },
 },
 ```
+
+**Important Notes:**
+
+- Use `mason-lspconfig.nvim` to install LSP servers, not `mason.nvim` directly
+- The package name in Mason is `copilot`, not `copilot-language-server`
+- You don't need to configure `nvim-lspconfig` servers manually - `blink-copilot` handles the LSP integration automatically
+- The Copilot Language Server will be available after installation through Mason
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -60,28 +60,20 @@ Here are some example configuration for using `blink-copilot` with [lazy.nvim][l
 <details>
 <summary><code>blink-copilot</code> + <code>Copilot Language Server</code></summary>
 
-**Installation Steps:**
-
-1. Install the Copilot Language Server via Mason:
-   - Open Neovim and run `:Mason`
-   - Search for `copilot` and install it
-   - Or use `:LspInstall copilot` to install it directly
-
-2. Sign in to Copilot:
-   - Run `:LspCopilotSignIn` to sign in
+Sign in to Copilot, or use the :LspCopilotSignIn command from https://github.com/neovim/nvim-lspconfig.
 
 ---
 
-**Option 1: Automatic Setup (Recommended)**
+**Option 1: Mason-lspconfig **
 
 <details>
 <summary>Using <code>mason-lspconfig.nvim</code> (simpler)</summary>
 
-This approach automatically handles the LSP server setup for you.
+
 
 ```lua
 {
-  "williamboman/mason-lspconfig.nvim",
+  "williamboman/mason-lspconfig.nvim", --No manual LSP configuration needed
   opts = {
     ensure_installed = { "copilot" },
   },
@@ -109,19 +101,19 @@ This approach automatically handles the LSP server setup for you.
 
 ---
 
-**Option 2: Manual Setup**
+**Option 2: Mason + Custom lspconfig**
 
 <details>
 <summary>Using <code>mason.nvim</code> + <code>nvim-lspconfig</code> (more control)</summary>
 
-This approach gives you more control over the LSP configuration.
+
 
 ```lua
 {
   "neovim/nvim-lspconfig",
   opts = {
     servers = {
-      copilot = {},
+      copilot = {}, -- manual LSP configuration
     },
   },
 },
@@ -150,13 +142,6 @@ This approach gives you more control over the LSP configuration.
 </details>
 
 ---
-
-**Important Notes:**
-
-- The package name in Mason is `copilot`, not `copilot-language-server`
-- `blink-copilot` handles the LSP integration automatically - you don't need additional LSP configuration
-- Choose Option 1 for simplicity, Option 2 for more control over LSP settings
-- The Copilot Language Server will be available after installation through Mason
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Here are some example configuration for using `blink-copilot` with [lazy.nvim][l
    - Or use `:LspInstall copilot` to install it directly
 
 2. Sign in to Copilot:
-   - Run `:Copilot auth` or follow the authentication flow when first using Copilot
+   - Run `:LspCopilotSignIn` to sign in
 
 **Configuration:**
 
@@ -78,7 +78,7 @@ Here are some example configuration for using `blink-copilot` with [lazy.nvim][l
   "williamboman/mason-lspconfig.nvim",
   opts = {
     ensure_installed = {
-      "copilot", -- Note: The package name is now just "copilot", not "copilot-language-server"
+      "copilot"
     },
   },
   dependencies = {

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Sign in to Copilot, or use the :LspCopilotSignIn command from https://github.com
 
 ---
 
-**Option 1: Mason-lspconfig **
+**Option 1: Mason-lspconfig**
 
 <details>
 <summary>Using <code>mason-lspconfig.nvim</code> (simpler)</summary>


### PR DESCRIPTION
I believe there was some confusions in README how to install Copilot-language-server, correct me if i'm wrong 